### PR TITLE
IMP: Hide un-needed Call Error Popup display

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons.jitsi</groupId>
     <artifactId>exo-jitsi</artifactId>
-    <version>1.1.x-SNAPSHOT</version>
+    <version>1.1.x-maintenance-SNAPSHOT</version>
   </parent>
   
   <artifactId>web-conferencing-jitsi-packaging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>org.exoplatform.addons.jitsi</groupId>
   <artifactId>exo-jitsi</artifactId>
-  <version>1.1.x-SNAPSHOT</version>
+  <version>1.1.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Jitsi</name>
   <description>eXo Jitsi portal extension (connector for Web Conferencing)</description>
@@ -52,9 +52,9 @@
     <!-- **************************************** -->
     <!-- Dependencies versions                    -->
     <!-- **************************************** -->
-    <addon.exo.web-conferencing.version>2.2.x-SNAPSHOT</addon.exo.web-conferencing.version>
-    <addon.exo.ecms.version>6.2.x-SNAPSHOT</addon.exo.ecms.version>
-    <org.exoplatform.platform-ui.version>6.2.x-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <addon.exo.web-conferencing.version>2.2.x-maintenance-SNAPSHOT</addon.exo.web-conferencing.version>
+    <addon.exo.ecms.version>6.2.x-maintenance-SNAPSHOT</addon.exo.ecms.version>
+    <org.exoplatform.platform-ui.version>6.2.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
     <!-- **************************************** -->
     <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
   </properties>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons.jitsi</groupId>
     <artifactId>exo-jitsi</artifactId>
-    <version>1.1.x-SNAPSHOT</version>
+    <version>1.1.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>web-conferencing-jitsi-services</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons.jitsi</groupId>
     <artifactId>exo-jitsi</artifactId>
-    <version>1.1.x-SNAPSHOT</version>
+    <version>1.1.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>web-conferencing-jitsi-webapp</artifactId>

--- a/webapp/src/main/webapp/js/webconferencing-jitsi.js
+++ b/webapp/src/main/webapp/js/webconferencing-jitsi.js
@@ -281,12 +281,10 @@
             } else {
               process.reject(err);
               log.error("Failed to get call info: " + callId, err);
-              webConferencing.showError("Getting call error", webConferencing.errorText(err));
             }
           } else {
             process.reject();
             log.error("Failed to get call info: " + callId);
-            webConferencing.showError("Getting call error", "Error read call information from the server");
           }
         });
         return process.promise();


### PR DESCRIPTION
Sometimes, a jitsi call error popup is displayed yet no current call was launched, and as the error is traced in browser console, I suggest to hide the popup error displayed for users to prevent any confusion

@ahamdi WDYT  ?