### PR TITLE
MAINT-50185: Fix the display of a blank page when launch a Jitsi call

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing-jitsi.js
+++ b/webapp/src/main/webapp/js/webconferencing-jitsi.js
@@ -333,13 +333,14 @@
                   // Start the call explicitly if it is in stopped state or state undefined/null.
                   // This way we will inform all parties about the call start.
                   log.info("Call exists but stopped. Starting call: " + callId);
-                  webConferencing.updateCall(callId, "started").then(call => {
+                  let callUpdate = webConferencing.updateCall(callId, "started");
+                  if (callUpdate) {
                     log.info("Call started: " + callId + " by " + context.currentUser.id);
-                    callProcess.resolve(call);
-                  }).catch(err => {
+                    callProcess.resolve(callUpdate);
+                  } else {
                     log.error("Failed to start a call: " + callId, err);
                     callProcess.reject("Failed to start a call: " + webConferencing.errorText(err));
-                  });
+                  }
                 } else {
                   // otherwise, call already running and no need to send notification to its parties
                   log.info("Call already running. Joining call: " + callId);

--- a/webapp/webpack.dev.js
+++ b/webapp/webpack.dev.js
@@ -6,7 +6,7 @@ const webpackCommonConfig = require("./webpack.common.js");
 const app = "jitsi";
 
 // add the server path to your server location path (it's a symlink in webapp folder to a real server')
-const exoServerPath = "exo-server";
+const exoServerPath = "/exo-server";
 
 let config = merge(webpackCommonConfig, {
 	output: {


### PR DESCRIPTION
**ISSUE**: When the state of the call is stopped the call wasn't able to continue the start after updating its state
because of a wrong passed argument for the `getProvider() function` in the comdetd request response resolving.
**FIX**: Set the right parameter for the `getProvider() function` to allow resolving the promise correctly when start the call