### PR TITLE
MAINT-42333: Fix unexpected close of space logo popover after receiving a jitsi call

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButton/main.js
+++ b/webapp/src/main/webapp/vue-apps/CallButton/main.js
@@ -141,8 +141,6 @@ export function initCallPopup(
   
   return exoi18n.loadLanguageAsync(lang, url).then((i18n) => {
     const container = document.createElement('div');
-    const parentContainer = document.getElementById('vuetify-apps');
-    parentContainer.parentElement.classList.add('call-popup');
     // TODO why we need an ID unique per page?
     document.body.appendChild(container);
     let onAccepted;

--- a/webapp/webpack.dev.js
+++ b/webapp/webpack.dev.js
@@ -6,7 +6,7 @@ const webpackCommonConfig = require("./webpack.common.js");
 const app = "jitsi";
 
 // add the server path to your server location path (it's a symlink in webapp folder to a real server')
-const exoServerPath = "exo-server";
+const exoServerPath = "/exo-server";
 
 let config = merge(webpackCommonConfig, {
 	output: {


### PR DESCRIPTION
**ISSUE**: A call-popup css class was added to vuetify-app container of vuetify apps without any positive effect even on the call popup is what caused this issue
**FIX**: remove the call-popup class from vuetify apps container.