### PR TITLE
MAINT-50873: Make sure to not show error popus when unexpected fail happens while updating call states

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing-jitsi.js
+++ b/webapp/src/main/webapp/js/webconferencing-jitsi.js
@@ -280,13 +280,11 @@
               process.resolve("stopped");
             } else {
               process.reject(err);
-              log.error("Failed to get call info: " + callId, err);
-              webConferencing.showError("Getting call error", webConferencing.errorText(err));
+              log.error("Failed to get call info: " + callId + " For user " + context.currentUser.id, JSON.stringify(err));
             }
           } else {
             process.reject();
-            log.error("Failed to get call info: " + callId);
-            webConferencing.showError("Getting call error", "Error read call information from the server");
+            log.error("Failed to get call info: " + callId + "For user " + context.currentUser.id);
           }
         });
         return process.promise();


### PR DESCRIPTION
Make sure to not show error popus when unexpected fail happens while updating call states as it's not a good way for ux as displaying a console browser log error should enough to indicate that an error occurs.