### PR TITLE
Fix retrieving language in Jitsi call window

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButton/main.js
+++ b/webapp/src/main/webapp/vue-apps/CallButton/main.js
@@ -5,7 +5,7 @@ Vue.component('jitsi-meet-button', JitsiMeetButton);
 const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 
 // getting language of user
-const lang = (eXo && eXo.env && eXo.env.portal && eXo.env.portal.language) || 'en';
+const lang = (window.eXo && eXo.env && eXo.env.portal && eXo.env.portal.language) || 'en';
 const localePortlet = 'locale.jitsi';
 const resourceBundleName = 'Jitsi';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/${localePortlet}.${resourceBundleName}-${lang}.json`;

--- a/webapp/src/main/webapp/vue-apps/Jitsi/main.js
+++ b/webapp/src/main/webapp/vue-apps/Jitsi/main.js
@@ -8,7 +8,7 @@ const vuetify = new Vuetify({
 });
 
 // getting language of user
-const lang = (eXo && eXo.env && eXo.env.portal && eXo.env.portal.language) || 'en';
+const lang = (window.eXo && window.eXo.env && window.eXo.env.portal && window.eXo.env.portal.language) || 'en';
 const localePortlet = 'locale.webconferencing';
 const resourceBundleName = 'Jitsi';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/${localePortlet}.${resourceBundleName}-${lang}.json`;


### PR DESCRIPTION
When displaying Jitsi Call window, sometimes an error of type `eXo is not defined` is displayed and crashes the page. This fix will ensure to avoid such a case