### PR TITLE
TASK-57515: Display the call button in big chat and in profile

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButton/components/JitsiMeetButton.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButton/components/JitsiMeetButton.vue
@@ -84,7 +84,7 @@ export default {
     generateButtonTitle: function(label, defaultText, icon) {
       if (this.parentClasses) {
         return {
-          title: this.parentClasses.includes('call-button-mini')
+          title: this.parentClasses.includes('call-button-mini') || this.parentClasses.includes('call-button')
             ? this.i18n.te(label)
               ? this.$t(label)
               : defaultText


### PR DESCRIPTION
Prior to this change, when we do have `WebRTC` call in the platform, the Call button is badly displayed with an arrow.
To fix this, insert this condition `this.parentClasses.includes('call-button')` in this function `generateButtonTitle`.