### PR TITLE
fix: Error 500 when launching a call - EXO-65875

### DIFF
--- a/webapp/src/main/java/org/exoplatform/webconferencing/jitsi/server/JitsiGateway.java
+++ b/webapp/src/main/java/org/exoplatform/webconferencing/jitsi/server/JitsiGateway.java
@@ -154,7 +154,7 @@ public class JitsiGateway extends AbstractHttpServlet {
     } else {
       HttpPost post = new HttpPost(requestUrl);
       try {
-        post.setEntity(new InputStreamEntity(req.getInputStream(), ContentType.create(req.getContentType())));
+        post.setEntity(new InputStreamEntity(req.getInputStream(), ContentType.parse(req.getContentType())));
       } catch (IOException e) {
         LOG.warn("Cannot set entity for post request  {} : {} ", requestUrl, e.getMessage());
       }


### PR DESCRIPTION
Before this fix, when launching a call, there is a request in error. When the request is forward by exo component to jitsi-call component, the mime type is extracted from the request, and we create an object ContentType with ContentType.create This object does not support if the mime type contains the charset, since last version of httpcore This commit replace the create function by parse, which return a contentType object and support charset