### PR TITLE
fix: jitsi call button is not well displayed in left menu level 2 - EXO-66752

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButton/components/JitsiMeetButton.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButton/components/JitsiMeetButton.vue
@@ -1,20 +1,15 @@
 <template>
-  <v-tooltip bottom>
-    <template v-slot:activator="{ on, attrs }">
-      <v-btn
-        ref="jitsi"
-        :ripple="false"
-        class="jitsiCallAction"
-        outlined
-        @click.stop.prevent="startCall"
-        v-bind="attrs"
-        v-on="on">
-        <i :class="buttonTitle.icon" class="uiIconSocPhone uiIconBlue ps-2"></i>
-        <span>{{ buttonTitle.title }}</span>
-      </v-btn>
-    </template>
+  <v-btn
+    id="btnJitsiButton"
+    class="jitsiCallAction"
+    :title="buttonTitle.title"
+    @click.stop.prevent="startCall"
+    v-bind="attrs"
+    v-on="on"
+    icon>
+    <v-icon size="16" class="uiIconStatus icon-default-color fas fa-phone" />
     <span>{{ buttonTitle.title }}</span>
-  </v-tooltip>
+  </v-btn>
 </template>
 
 <script>
@@ -121,18 +116,6 @@ export default {
       opacity: 0;
       background: transparent;
     }
-    &:hover {
-      &::before {
-        color: @primaryColor;
-        opacity: 0;
-      }
-      // i {
-      // color: white;
-      // }
-      // span {
-      // color: white;
-      // }
-    }
   }
   .call-button-container {
     button {
@@ -151,6 +134,23 @@ export default {
           span {
             color: unset;
           }
+        }
+      }
+    }
+  }
+}
+#chat-application {
+  .call-button-container {
+    .theme--light.v-btn {
+      background: inherit;
+      &:focus::before {
+        opacity: 0;
+        background: transparent;
+      }
+      &:hover {
+        &::before {
+          color: @primaryColor;
+          opacity: 0;
         }
       }
     }


### PR DESCRIPTION
Before this fix, the button is not aligned with other in left menu level 2 (on a space). In addition, when overring the button, the hover shadow is not displayed This fix modifies the vue component which display the jitsi button in order to respect the other button organization. In addition, css are updated to have the correct display everywhere the button is displayed (left menu level 2, space popover, chat drawer, chat application, in which we dont want the shadow)