### PR TITLE
feat: Upgrade To Tomcat 10 - Meeds-io/MIPs#76

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/jitsi/rest/JitsiContextResource.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/jitsi/rest/JitsiContextResource.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.jcr.RepositoryException;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;

--- a/services/src/main/java/org/exoplatform/webconferencing/jitsi/rest/filter/WebconferencingSessionFilter.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/jitsi/rest/filter/WebconferencingSessionFilter.java
@@ -6,13 +6,13 @@ package org.exoplatform.webconferencing.jitsi.rest.filter;
 import java.io.IOException;
 import java.util.Map;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.container.ExoContainer;

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -48,36 +48,6 @@
     </dependency>
     <!-- Application dependencies-->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.core</groupId>
-      <artifactId>exo.core.component.organization.api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.kernel</groupId>
-      <artifactId>exo.kernel.commons</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.kernel</groupId>
-      <artifactId>exo.kernel.container</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.social</groupId>
       <artifactId>social-component-core</artifactId>
       <scope>provided</scope>

--- a/webapp/src/main/java/org/exoplatform/webconferencing/jitsi/server/JitsiGateway.java
+++ b/webapp/src/main/java/org/exoplatform/webconferencing/jitsi/server/JitsiGateway.java
@@ -31,11 +31,11 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
-import javax.servlet.AsyncContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;


### PR DESCRIPTION
This change will upgrade Java Servlet API 6.0 packages to be compatible with Tomcat 10 and will delete third party libraries declaration from `pom.xml` file to load it in transitive way.