### PR TITLE
fix: call button are not displayed when user is not administrator - EXO-70783

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/jitsi/rest/JitsiContextResource.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/jitsi/rest/JitsiContextResource.java
@@ -191,7 +191,7 @@ public class JitsiContextResource implements ResourceContainer {
 
   }
   @GET
-  @RolesAllowed("administrators")
+  @RolesAllowed("users")
   @Path("/connectorsettings")
   @Produces(MediaType.APPLICATION_JSON)
   @Operation(


### PR DESCRIPTION
…XO-70783

Before this fix, the call button is not dsiplayed because the rest service to get call provider configuration is limited to administrators This commit open the service to users.