### PR TITLE
fix: Unable to deactivate jitsi in a space - EXO-71467

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/jitsi/JitsiProvider.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/jitsi/JitsiProvider.java
@@ -217,7 +217,14 @@ public class JitsiProvider extends CallProvider {
 
   @Override
   public List<ActiveCallProvider> getActiveProvidersForSpace(String spaceId) {
-    return new ArrayList<>(List.of(new ActiveCallProvider("jitsi", TITLE, null, true, isConfiguredForIdentity(spaceId))));
+    Space space = spaceService.getSpaceById(spaceId);
+    if (space!=null) {
+
+      return new ArrayList<>(List.of(new ActiveCallProvider("jitsi", TITLE, null, true, isConfiguredForIdentity(space.getPrettyName()))));
+    } else {
+      return new ArrayList<>();
+    }
+
   }
 
   /**


### PR DESCRIPTION
Before this fix, when I deactivate jisti in a space, and then refresh the page, the provider is still active This is due to the fact that the settings is saved with the spaceId and read with the spaceRemoteId, which not correspond

This commit ensure to use the correct parameter