### PR TITLE
fix: Improve Add a visioconference link with external video conference - EXO-70996

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing-jitsi.js
+++ b/webapp/src/main/webapp/js/webconferencing-jitsi.js
@@ -45,6 +45,11 @@
       this.groupSupported = true;
 
       /**
+       * With Jitsi Visio, we dont allow to modify event url
+       */
+      this.canModifyEventUrl = false;
+
+      /**
        * MUST return a call type name. If several types supported, this one is
        * assumed as major one and it will be used for referring this connector
        * in getProvider() and similar methods. This type also should listed in


### PR DESCRIPTION
Before this fix, when the provider allow to modify the url of the visio, the url cannot be changed This commit add the possibility to update the visio url