### PR TITLE
fix: Ensure that only needed static resources are redirected to Jitsi Gateway servlet - Meeds-io/MIPs#134

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -59,8 +59,16 @@
   </servlet-mapping>
   <servlet-mapping>
     <servlet-name>JitsiGateway</servlet-name>
-    <url-pattern>/*</url-pattern>
+    <url-pattern>/</url-pattern>
+    <url-pattern>/meet/*</url-pattern>
+    <url-pattern>/jitsi/js/jitsi-app.bundle.js</url-pattern>
+    <url-pattern>/skin/call.css</url-pattern>
+    <url-pattern>/js/common.js</url-pattern>
+    <url-pattern>/js/require.js</url-pattern>
+    <url-pattern>/js/call.js</url-pattern>
+    <url-pattern>/images/favicon.ico</url-pattern>
+    <url-pattern>/images/logo.png</url-pattern>
+    <url-pattern>/jitsi/portal/rest/*</url-pattern>
   </servlet-mapping>
-
 
 </web-app>


### PR DESCRIPTION
Before this fix, static ressources on eXo side are served by the servlet. This is incompatible with the new resource serving introduce in MIP-134