### PR TITLE
fix: user profile - bug - start a call button has different display - EXO-71671.

### DIFF
--- a/webapp/src/main/webapp/skin/less/jitsi.less
+++ b/webapp/src/main/webapp/skin/less/jitsi.less
@@ -291,7 +291,6 @@
 #profileHeaderActions .profileHeaderActionComponents {
   .call-button-container:hover {
     background-color: @grayLighter!important;
-    opacity: 0.08;
   }
   @media (min-width: @minLargeTabletWidth) {
     .call-button {


### PR DESCRIPTION
Before this change, when access to user profile and check start a call button, start a call button has different display compared to send a kudos & open chat. After this change, icon and text of start a call have the same color as the other buttons.