### PR TITLE
fix : user profile - bug - start a call button has different display  - EXO-71671

### DIFF
--- a/webapp/src/main/webapp/skin/less/jitsi.less
+++ b/webapp/src/main/webapp/skin/less/jitsi.less
@@ -17,98 +17,94 @@
 }
 
 /* Styles for Jitsi in callPopup */
-#incomingCallPopup {
+  
+.incomingCallPopup.v-dialog {
+  border-radius: 2px;
+  height: 160px;
   .spacer {
     flex-grow: unset !important;
     width: 12%;
   }
-  .v-dialog {
+  .v-sheet.v-card {
     border-radius: 2px;
     height: 160px;
-    .v-sheet.v-card {
-      border-radius: 2px;
-      height: 160px;
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      grid-template-rows: repeat(2, 80px);
-      grid-auto-rows: 10px;
-      width: initial;
-      [class^="uiIcon"].start-call {
-        position: absolute;
-        top: 15%;
-        left: 24%;
-        &::before {
-          content: "\e61c";
-          color: #fb8e18;
-          font-size: 20px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, 80px);
+    grid-auto-rows: 10px;
+    width: initial;
+    [class^="uiIcon"].start-call {
+      position: absolute;
+      top: 15%;
+      left: 24%;
+      &::before {
+        content: "\e61c";
+        color: #fb8e18;
+        font-size: 20px;
+      }
+    }
+    .v-avatar {
+      border-radius: 50% !important;
+      align-self: center;
+      justify-self: center;
+      top: 15px;
+      left: -15px;
+    }
+    .v-card__text {
+      grid-column: ~"2 / span 2";
+      grid-row: ~"1 / span 1";
+      padding: 20px 15px 20px 0px;
+      font-size: 16px;
+      color: #333;
+    }
+    .v-card__actions {
+      grid-column: ~"1 / span 3";
+      grid-row: ~"2 / span 1";
+      padding: 8px 0px !important;
+      display: flex;
+      justify-content: center;
+      .v-btn {
+        padding: 0;
+        height: 50px;
+        width: 50px;
+        border: 1px solid;
+        margin-left: 0px !important;
+        .v-btn__content {
+          [class^="uiIcon"] {
+            position: relative;
+            height: 25px;
+            width: 50px;
+            &::before {
+              position: absolute;
+              font-size: 24px;
+              right: 50%;
+              transform: translateX(50%);
+            }
+          }
+        }
+        &.accept-button {
+          .uiIconPopupPhone {
+            color: white;
+            &::before {
+              content: "\e92b";
+            }
+          }
+        }
+        &.decline-button {
+          .uiIconPopupClose {
+            opacity: 1;
+            &::before {
+              color: #aeb3b7;
+              content: "\e9d2";
+            }
+          }
         }
       }
-      .v-avatar {
-        border-radius: 50% !important;
-        align-self: center;
-        justify-self: center;
-        top: 15px;
-        left: -15px;
-      }
-      .v-card__text {
-        grid-column: 2 / span 2;
-        grid-row: 1 / span 1;
-        padding: 20px 15px 20px 0px;
-        font-size: 16px;
+      .button-title {
+        font-weight: 700;
+        font-size: 14px;
+        cursor: pointer;
         color: #333;
-      }
-      .v-card__actions {
-        grid-column: 1 / span 3;
-        grid-row: 2 / span 1;
-        padding: 8px 0px !important;
-        display: flex;
-        justify-content: center;
-        .v-btn {
-          padding: 0;
-          height: 50px;
-          width: 50px;
-          border: 1px solid;
-          margin-left: 0px !important;
-          .v-btn__content {
-            [class^="uiIcon"] {
-              position: relative;
-              height: 25px;
-              width: 50px;
-              &::before {
-                position: absolute;
-                font-size: 24px;
-                right: 50%;
-                transform: translateX(50%);
-              }
-            }
-          }
-          &.accept-button {
-            .uiIconPopupPhone {
-              color: white;
-              &::before {
-                content: "\e92b";
-              }
-            }
-          }
-          &.decline-button {
-            //&:before {
-            //  color: transparent;
-            //}
-            .uiIconPopupClose {
-              opacity: 1;
-              &::before {
-                color: #aeb3b7;
-                content: "\e9d2";
-              }
-            }
-          }
-        }
-        .button-title {
-          font-weight: 700;
-          font-size: 14px;
-          cursor: pointer;
-          color: #333;
-        }
       }
     }
   }
@@ -291,7 +287,20 @@
   }
 }
 #profileHeaderActions .profileHeaderActionComponents {
+  .call-button-container {
+    .dropdown-vue {
+      .buttons-container {
+        z-index: @zindexDropdown !important;
+        [class^="call-button-container-"]:hover {
+          background-color: @grayLighter!important;
+        }
+      }
+    }
+  }        
   .call-button-container:hover {
+    background-color: @grayLighter!important;
+  }
+  .dropdown-header:hover {
     background-color: @grayLighter!important;
   }
   @media (min-width: @minLargeTabletWidth) {
@@ -302,11 +311,9 @@
   .buttonTitle {
     color: inherit;
   }
-  .jitsiCallAction {
+  i.fa-video {
     color: @primaryColor !important;
-    i {
-      font-size: medium !important;
-      margin: 0 !important;
-    }
+    font-size: medium !important;
+    margin: 0 !important;
   }
 }

--- a/webapp/src/main/webapp/vue-apps/CallButton/components/CallPopup.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButton/components/CallPopup.vue
@@ -3,10 +3,9 @@
     <v-app v-if="isDialogVisible">
       <v-dialog
         ref="incoming"
-        id="incomingCallPopup"
         :retain-focus="false"
         v-model="isDialogVisible"
-        content-class="incoming-dialog"
+        content-class="incoming-dialog incomingCallPopup"
         no-click-animation
         persistent
         hide-overlay


### PR DESCRIPTION
Before this change, when accessing user profile and checking start a call button, start a call button has different display compared to send a kudos and open chat. to fix this problem, first apply the necessary style to be compatible with the other buttons, then integrate the platform-ui-skin dependency and finally, group the styles in jitsi.less file and delete both variables.less and mixins.less files. After this change, icon and text of start a call have the same color as the other buttons.