### PR TITLE
fix: Remove warning in console server startup - EXO-74326

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -36,6 +36,7 @@
     <name>transliteration</name>
     <load-group>webConferencingJitsiGRP</load-group>
     <script>
+      <minify>false</minify>
       <path>/js/transliteration.min.js</path>
     </script>
   </module>


### PR DESCRIPTION
Before this fix, there was an error in server startup logs This commit ensure that the concerned js file is not minified as it is already minified
