### PR TITLE
fix: Fix binary resource streaming in JitsiGateway to prevent 0 KB assets EXO-72351 

### DIFF
--- a/webapp/src/main/java/org/exoplatform/webconferencing/jitsi/server/JitsiGateway.java
+++ b/webapp/src/main/java/org/exoplatform/webconferencing/jitsi/server/JitsiGateway.java
@@ -214,10 +214,20 @@ public class JitsiGateway extends AbstractHttpServlet {
       HttpEntity entity = response.getEntity();
       if (entity != null) {
         if (resp.getContentType() != null && resp.getContentType().startsWith(APPLICATION_JSON)) {
+          // JSON can be safely written as text
           resp.setCharacterEncoding(UTF_8);
           resp.getWriter().write(EntityUtils.toString(entity, UTF_8));
         } else {
-          resp.getWriter().write(EntityUtils.toString(entity));
+          // For binary (images, css, js, pdf, etc.) → stream raw bytes
+          try (InputStream in = entity.getContent();
+              OutputStream out = resp.getOutputStream()) {
+              byte[] buffer = new byte[8192];
+              int len;
+              while ((len = in.read(buffer)) != -1) {
+                  out.write(buffer, 0, len);
+              }
+              out.flush();
+          }
         }
       }
     } catch (IOException e) {


### PR DESCRIPTION
Currently, JitsiGateway.forward() incorrectly handles all HTTP responses by converting them to text using EntityUtils.toString(). This corrupts binary resources such as images, PDFs, and other static assets when proxied through the gateway, resulting in 0 KB files.

Changes made:

Binary responses (non-JSON) are now streamed directly to the client using OutputStream instead of Writer.

JSON responses continue to be handled as text.

Ensures that images like logo.png served via /jitsi/images/ are delivered correctly.

This fix resolves the issue where proxied static resources appear empty and preserves proper handling of both JSON and binary content.