### PR TITLE
fix : Correct display for jitsi button - EXO-85837

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButton/components/JitsiMeetButton.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButton/components/JitsiMeetButton.vue
@@ -17,8 +17,7 @@
         </v-btn>
       </template>
       <span v-if="displayTooltip" class="buttonTitle">{{ buttonTitle.title }}</span>
-    </v-tooltip>
-    <span
+    </v-tooltip><span
       v-if="displayConnectorName"
       @click.stop.prevent="startCall">{{ 'Jitsi' }}</span>
     <span


### PR DESCRIPTION
Before this fix, the jitsi button display a white space not visible, which make connector name not aligned This commit remove the not needed space